### PR TITLE
utility "themes"

### DIFF
--- a/themes/utility/app-controls-fade.css
+++ b/themes/utility/app-controls-fade.css
@@ -1,0 +1,42 @@
+/** Fade out window controls **/
+.AppControls {
+    opacity: 0;
+    
+    transition: opacity;
+    transition-timing-function: ease-out;
+    transition-duration: 250ms;
+
+    -ms-transition: opacity;
+    -ms-transition-timing-function: ease-out;
+    -ms-transition-duration: 250ms;
+
+    -moz-transition: opacity;
+    -moz-transition-timing-function: ease-out;
+    -moz-transition-duration: 250ms;
+
+    -webkit-transition: opacity;
+    -webkit-transition-timing-function: ease-out;
+    -webkit-transition-duration: 250ms;
+    
+    transition-delay: 1s;
+}
+
+.AppControls:hover {
+    opacity: 1;
+    
+    transition: opacity;
+    transition-timing-function: ease-out;
+    transition-duration: 250ms;
+
+    -ms-transition: opacity;
+    -ms-transition-timing-function: ease-out;
+    -ms-transition-duration: 250ms;
+
+    -moz-transition: opacity;
+    -moz-transition-timing-function: ease-out;
+    -moz-transition-duration: 250ms;
+
+    -webkit-transition: opacity;
+    -webkit-transition-timing-function: ease-out;
+    -webkit-transition-duration: 250ms;
+}

--- a/themes/utility/app-controls-fade.css
+++ b/themes/utility/app-controls-fade.css
@@ -6,14 +6,6 @@
     transition-timing-function: ease-out;
     transition-duration: 250ms;
 
-    -ms-transition: opacity;
-    -ms-transition-timing-function: ease-out;
-    -ms-transition-duration: 250ms;
-
-    -moz-transition: opacity;
-    -moz-transition-timing-function: ease-out;
-    -moz-transition-duration: 250ms;
-
     -webkit-transition: opacity;
     -webkit-transition-timing-function: ease-out;
     -webkit-transition-duration: 250ms;
@@ -27,14 +19,6 @@
     transition: opacity;
     transition-timing-function: ease-out;
     transition-duration: 250ms;
-
-    -ms-transition: opacity;
-    -ms-transition-timing-function: ease-out;
-    -ms-transition-duration: 250ms;
-
-    -moz-transition: opacity;
-    -moz-transition-timing-function: ease-out;
-    -moz-transition-duration: 250ms;
 
     -webkit-transition: opacity;
     -webkit-transition-timing-function: ease-out;

--- a/themes/utility/hide-chat-divider.css
+++ b/themes/utility/hide-chat-divider.css
@@ -1,0 +1,6 @@
+/* Visually (not functionally) hide the draggable divider for expanding chat summaries */
+.mx_MatrixChat > .mx_ResizeHandle, .mx_RightPanel_ResizeWrapper .mx_ResizeHandle {
+    margin: none;
+    -webkit-box-shadow: none;
+    box-shadow: none;
+}

--- a/themes/utility/minimal-titlebar-left.css
+++ b/themes/utility/minimal-titlebar-left.css
@@ -1,8 +1,5 @@
-/** Hide the (mostly empty) title bar, and move the window controls into the empty left-side area **/
-/* Notes:
-  - I generally tried to inherit most styles
-  - There is a sacrifice to the header width draggable area
-*/
+/** Hide the (mostly empty) title bar
+    move the window controls into the empty left-side area **/
 
 :root {
   --app-control-wide: 138px;

--- a/themes/utility/minimal-titlebar-right.css
+++ b/themes/utility/minimal-titlebar-right.css
@@ -1,0 +1,23 @@
+/** Hide the (mostly empty) title bar
+    move the window controls into the right-side action area **/
+
+:root {
+  --app-control-wide: 138px;
+  --app-control-right: 15px;
+  --app-control-top: 12px;
+}
+
+.AppControls {
+  position: absolute;
+  top: var(--app-control-top);
+  z-index: 1000;
+  right: var(--app-control-right);
+}
+.AppControls-button { height: 100%; }
+.mx_RoomHeader_rightActions {
+  position: relative;
+  right: calc(var(--app-control-wide) + var(--app-control-right)*2);
+}
+.mx_RoomHeader_name {
+  max-width: 345px;
+}

--- a/themes/utility/minimal-titlebar.css
+++ b/themes/utility/minimal-titlebar.css
@@ -1,0 +1,28 @@
+/** Hide the (mostly empty) title bar, and move the window controls into the empty left-side area **/
+/* Notes: 
+  - I generally tried to inherit most styles
+  - There is a sacrifice to the header width draggable area
+*/
+
+:root {
+  --app-control-wide: 138px;
+  --app-control-left: 15px;
+  --app-control-top: 12px;
+}
+
+.AppControls {
+    position: absolute;
+    top: var(--app-control-top);
+    z-index: 1000;
+    left: var(--app-control-left);
+    -webkit-app-region: no-drag;
+}
+.AppControls-button { height: 100%; }
+.bp_TitleBar {
+    height: 0;
+    min-height: 0;
+}
+.bp_Header {
+    width: calc(100% - var(--app-control-wide) - var(--app-control-left));
+    align-self: end;
+}

--- a/themes/utility/minimal-titlebar.css
+++ b/themes/utility/minimal-titlebar.css
@@ -1,5 +1,5 @@
 /** Hide the (mostly empty) title bar, and move the window controls into the empty left-side area **/
-/* Notes: 
+/* Notes:
   - I generally tried to inherit most styles
   - There is a sacrifice to the header width draggable area
 */
@@ -18,8 +18,8 @@
 }
 .AppControls-button { height: 100%; }
 .bp_TitleBar {
-    height: 0;
-    min-height: 0;
+    height: 0!important;
+    min-height: unset!important;
 }
 .bp_Header {
     width: calc(100% - var(--app-control-wide) - var(--app-control-left));

--- a/themes/utility/minimal-titlebar.css
+++ b/themes/utility/minimal-titlebar.css
@@ -15,7 +15,6 @@
     top: var(--app-control-top);
     z-index: 1000;
     left: var(--app-control-left);
-    -webkit-app-region: no-drag;
 }
 .AppControls-button { height: 100%; }
 .bp_TitleBar {


### PR DESCRIPTION
- Create a utilities folder for reusable css that could be added onto other themes for additional functionality
- add a utility for (primarily not-mac) hiding the mostly empty title bar and moving window controls to their windows-like placement
- add a utility for hiding app control buttons (minimize, maximize, close)