### PR TITLE
Fixed a weird overlap with the right buttons 

### DIFF
--- a/themes/utility/minimal-titlebar-right.css
+++ b/themes/utility/minimal-titlebar-right.css
@@ -11,13 +11,18 @@
   position: absolute;
   top: var(--app-control-top);
   z-index: 1000;
+  width: var(--app-control-wide);
   right: var(--app-control-right);
 }
 .AppControls-button { height: 100%; }
 .mx_RoomHeader_rightActions {
   position: relative;
-  right: calc(var(--app-control-wide) + var(--app-control-right)*2);
+  right: var(--app-control-right);
 }
 .mx_RoomHeader_name {
   max-width: 345px;
+}
+
+.mx_RoomHeader_wrapper {
+  width: calc((100% - var(--app-control-wide)) - var(--app-control-right) * 2);
 }


### PR DESCRIPTION
Fixed `minimal-title-bar.css` allowing overlap between the window buttons and room header right buttons.

| Before | After |
| ---------- | -------- |
|   ![Before Normal](https://github.com/beeper/themes/assets/29639914/85ff02fc-f696-4d42-84bb-1587b1bb4dea) |      ![After Normal](https://github.com/beeper/themes/assets/29639914/7c6c5f63-3e62-416f-903b-ae33b4fd11a7) |     
| ![Before Hover](https://github.com/beeper/themes/assets/29639914/3e22ca3b-7322-4329-a0b7-38b6d8b59d5d) |     ![After Hover](https://github.com/beeper/themes/assets/29639914/c3087e22-4b61-4df7-b164-da6bdf211990)   |