### PR TITLE
minimalist theme ✨ 

### DIFF
--- a/themes/minimalist.css
+++ b/themes/minimalist.css
@@ -21,3 +21,65 @@
   width: 30px !important;
   height: 30px !important;
 }
+
+/* hides the "all" or "read" tabs */
+.rooms_actions {
+  display: none !important;
+}
+
+/* sets height of each chat change this if it feels too compact */
+[data-type="bp_RoomTile"] > div {
+  height: 40px !important
+}
+
+/* position network icon absolutely to the right and centered vertically */
+[data-type="bp_RoomTile"] > div > div > div {
+  position: absolute !important;
+  right: 2%;
+  top: 50%;
+  transform: translateY(-50%);
+  height: auto !important;
+}
+
+/* hide message previews ... i mean ... ¯\_(ツ)_/¯ */
+[data-type="bp_RoomTile"] > div > div > div > span {
+  display: none !important;
+}
+
+/* trim network icon styles */
+[data-type="bp_RoomTile"] > div > div > div > div {
+  margin: 0 !important;
+}
+
+/* hide pin and archive actions. can use shortcuts ;) */
+[data-type="bp_RoomTile"] > div > div:last-child {
+  display: none !important;
+}
+
+/* hide time the message was sent and 'message read' indicator */
+[data-type="bp_RoomTile"] > div > div > span > span:last-child {
+  display: none !important;
+}
+
+/* remove margins and center content vertically */
+[data-type="bp_RoomTile"] > div > div:nth-last-child(2) {
+  justify-content: center !important;
+  margin: 0 !important;
+  height: 100% !important;
+}
+
+/* half the size of the avatars */
+img.mx_BaseAvatar.mx_BaseAvatar_image.avatar {
+  width: 22px !important;
+  height: 22px !important;
+}
+
+/* remove the favorite indicator (lil heart) */
+.favourite-indicator {
+  display: none !important;
+}
+
+/* hide the svg that cuts a hole in the avatar for where it puts the indicator */
+.favourite-avatar svg {
+  display: none !important;
+}

--- a/themes/minimalist.css
+++ b/themes/minimalist.css
@@ -1,0 +1,23 @@
+.favourites__tiles {
+  grid-row-gap: 2px !important;
+  row-gap: 2px !important;
+}
+
+.favourites__row {
+  grid-gap: 2px !important;
+  gap: 2px !important;
+}
+
+.favourites__row div {
+  height: 40px !important;
+  width: 40px !important;
+}
+
+.favourites__row .outline > span {
+  display: none;
+}
+
+.favourites__row .outline img {
+  width: 30px !important;
+  height: 30px !important;
+}

--- a/themes/minimalist.css
+++ b/themes/minimalist.css
@@ -151,3 +151,13 @@ div._33NHwSNM8FexMEXbDIk3OS {
 div.yyTXN-4uV3hAH2aSFTXOx._3N3OmnoVC-8oD9DeAi02W6 {
   display: none !important;
 }
+
+/* hide the welcome to beeper thing */
+div.mx_HomePage_default_wrapper {
+  display: none !important;
+}
+
+/* hide the 'you're an inbox wizard, harry' message */
+div.unread_hint {
+  display: none !important;
+}

--- a/themes/minimalist.css
+++ b/themes/minimalist.css
@@ -111,3 +111,8 @@ div.mx_BaseAvatar_image {
 div.wTC2UwiI_4Uijt6DA-jk4 {
   display: none !important;
 }
+
+/* hide group in the room tile's name */
+span._1-Yq5JwltweehijoGRoQdJ {
+  display: none !important;
+}

--- a/themes/minimalist.css
+++ b/themes/minimalist.css
@@ -116,3 +116,8 @@ div.wTC2UwiI_4Uijt6DA-jk4 {
 span._1-Yq5JwltweehijoGRoQdJ {
   display: none !important;
 }
+
+/* remove red line when new messages come in */
+div._2aD0Xwn49yQeca7cYc8SV8 {
+  display: none !important;
+}

--- a/themes/minimalist.css
+++ b/themes/minimalist.css
@@ -121,3 +121,28 @@ span._1-Yq5JwltweehijoGRoQdJ {
 div._2aD0Xwn49yQeca7cYc8SV8 {
   display: none !important;
 }
+
+/* remove 'seen by' indicator from your messages */
+div._17LFFkKO2F5EhV-hOzGQQy.jeKTrHx2Glq6tJS-DHVDJ {
+  display: none !important;
+}
+
+/* remove sender's names from messages */
+div._2MZGYxx5u9QBXJiJXyuSE6 {
+  display: none !important;
+}
+
+/* remove 'seen by' on messages from other people */
+div._17LFFkKO2F5EhV-hOzGQQy {
+  display: none !important;
+}
+
+/* remove floating archive button on side bar */
+div._1BqyLbX2P4Ugt-sdNnI9Ob._3P3fvvlfCyimK5Wx17JEV {
+  display: none !important;
+}
+
+/* hide the title of the chat on the top */
+div._33NHwSNM8FexMEXbDIk3OS {
+  display: none !important;
+}

--- a/themes/minimalist.css
+++ b/themes/minimalist.css
@@ -96,3 +96,18 @@ div.mx_BaseAvatar_image {
 .favourite-avatar svg {
   display: none !important;
 }
+
+/* chip that says which day the messages are from */
+._3B1XE-zAqDXtz0zu-w-Fmb {
+  display: none !important;
+}
+
+/* message context menu that appears when you hover over them */
+._3SCwVlBxZJeikuUJW-l2ua {
+  display: none !important;
+}
+
+/* the time next to the message */
+div.wTC2UwiI_4Uijt6DA-jk4 {
+  display: none !important;
+}

--- a/themes/minimalist.css
+++ b/themes/minimalist.css
@@ -146,3 +146,8 @@ div._1BqyLbX2P4Ugt-sdNnI9Ob._3P3fvvlfCyimK5Wx17JEV {
 div._33NHwSNM8FexMEXbDIk3OS {
   display: none !important;
 }
+
+/* hide 'seen at' in private messages */
+div.yyTXN-4uV3hAH2aSFTXOx._3N3OmnoVC-8oD9DeAi02W6 {
+  display: none !important;
+}

--- a/themes/minimalist.css
+++ b/themes/minimalist.css
@@ -74,6 +74,19 @@ img.mx_BaseAvatar.mx_BaseAvatar_image.avatar {
   height: 22px !important;
 }
 
+/* half the size of placeholder avatars */
+span.mx_BaseAvatar_initial {
+  width: 22px !important;
+  height: 22px !important;
+  font-size: 10px !important;
+  line-height: 22px !important;
+}
+
+div.mx_BaseAvatar_image {
+  width: 22px !important;
+  height: 22px !important;
+}
+
 /* remove the favorite indicator (lil heart) */
 .favourite-indicator {
   display: none !important;


### PR DESCRIPTION
# Overview

Minimalist theme for beeper desktop ✨ 

⚠️ work in progress, still wonky

- [x] removes names from favorites
- [x] reduces avatar size of favorites
- [x] remove room actions (all and read tabs)
- [x] remove time from room tiles 
- [x] remove "message read" indicatores from room tiles
- [x] remove message previews in room tiles
- [x] make room tiles more compact 
- [x] remove pin and archive action items on the room tile
- [ ] todo - update readme
- [ ] todo - when resizing room tile prevent network/notification icon and name from overlapping each other
- [ ] todo - fix inconsistent avatar size when the person has placeholder image
