### PR TITLE
New Theme: Nord for Beeper v3

### DIFF
--- a/v3/README.md
+++ b/v3/README.md
@@ -32,7 +32,7 @@ View [variables.scss](https://github.com/beeper/themes/tree/main/variables.scss)
 |:---:|:---:|
 | ![image](https://github.com/beeper/themes/blob/main/v3/themes/windows95.png) [**Windows 95 (light)**](https://github.com/beeper/themes/blob/main/v3/themes/windows95.css) by @imjoshin | ![image](https://github.com/beeper/themes/blob/main/v3/themes/bubbly.png) [**Bubbly**](https://github.com/beeper/themes/blob/main/v3/themes/bubbly.css) by @imjoshin |
 | ![image](https://user-images.githubusercontent.com/4341881/184789029-0a8f03bc-1691-4998-875a-90f79d6bab82.png) [**Metrology**](https://github.com/Madelena/metrology-for-beeper) by [@Madelena](https://github.com/Madelena) <br/> Dark/light modes and multiple colors included. Based on Metro Design System. | ![image](https://user-images.githubusercontent.com/4341881/184405906-45f67b70-dd0b-4457-8d55-8633cf497abc.png) [**Metrology**](https://github.com/Madelena/metrology-for-beeper) by [@Madelena](https://github.com/Madelena) <br/> Dark/light modes and multiple colors included. Based on Metro Design System. |
-| ![image](https://github.com/NSPC911/beeper-css/blob/main/nord-v3.png)<br>[**Nord v3**](https://github.com/NSPC911/beeper-css/blob/main/nord-v3.css)  by @nspg911 | |
+| ![image](https://raw.githubusercontent.com/NSPC911/themes/refs/heads/beeper/nord-v3.png)<br>[**Nord v3**](https://github.com/NSPC911/themes/blob/beeper/nord-v3.css)  by [@NSPC911](https://github.com/NSPC911) | |
 
 
 

--- a/v3/README.md
+++ b/v3/README.md
@@ -30,8 +30,9 @@ View [variables.scss](https://github.com/beeper/themes/tree/main/variables.scss)
 
 | | |
 |:---:|:---:|
-| ![image](https://github.com/beeper/themes/blob/main/themes/windows95.png) [**Windows 95 (light)**](https://github.com/beeper/themes/blob/main/themes/windows95.css) by @imjoshin | ![image](https://github.com/beeper/themes/blob/main/themes/bubbly.png) [**Bubbly**](https://github.com/beeper/themes/blob/main/themes/bubbly.css) by @imjoshin |
+| ![image](https://github.com/beeper/themes/blob/main/v3/themes/windows95.png) [**Windows 95 (light)**](https://github.com/beeper/themes/blob/main/v3/themes/windows95.css) by @imjoshin | ![image](https://github.com/beeper/themes/blob/main/v3/themes/bubbly.png) [**Bubbly**](https://github.com/beeper/themes/blob/main/v3/themes/bubbly.css) by @imjoshin |
 | ![image](https://user-images.githubusercontent.com/4341881/184789029-0a8f03bc-1691-4998-875a-90f79d6bab82.png) [**Metrology**](https://github.com/Madelena/metrology-for-beeper) by [@Madelena](https://github.com/Madelena) <br/> Dark/light modes and multiple colors included. Based on Metro Design System. | ![image](https://user-images.githubusercontent.com/4341881/184405906-45f67b70-dd0b-4457-8d55-8633cf497abc.png) [**Metrology**](https://github.com/Madelena/metrology-for-beeper) by [@Madelena](https://github.com/Madelena) <br/> Dark/light modes and multiple colors included. Based on Metro Design System. |
+| ![image](https://github.com/NSPC911/beeper-css/blob/main/nord-v3.png)<br>[**Nord v3**](https://github.com/NSPC911/beeper-css/blob/main/nord-v3.css)  by @nspg911 | |
 
 
 


### PR DESCRIPTION
After a day of messing around, I present to you, Nord v3!

It's a very accurate representation of the Nord palette inspired by [refact0r/midnight-discord](https://github.com/refact0r/midnight-discord)'s Nord theme

Screenshot
![image](https://raw.githubusercontent.com/NSPC911/beeper-css/refs/heads/main/nord-v3.png) <sub>with a ton of blurring, I really don't want to dox myself</sub>

For the censoring theme, I have a snippet at https://github.com/NSPC911/beeper-css/blob/main/showcase.css

[Link to the theme](https://github.com/NSPC911/beeper-css/blob/main/nord-v3.css)

Variables
```css
:root {
    --colormix: in oklab; /* recommend oklab, whatever your choice */
    --beeper-theme-color: color-mix(var(--colormix), var(--nord9) 50%, var(--nord10) 50%);
    --use-3d-toggles: 0; /* set to 1 to enable */
    --transition-duration: 0.125s; /* set to 0 to disable */
    --chatview__message_self__backgroundcolor: var(--nord10);
    --chatview__backgroundcolor: var(--nord0);
    --chatview__composer__backgroundcolor: var(--nord1);
}
```